### PR TITLE
Add setting to enable copy buttons

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -38,6 +38,7 @@ import {
 import {
   distanceUnitAtom,
   enableAdvancedScopesAtom,
+  foodLogShowCopyIndividualButtonAtom,
   foodLogTotalsPositionAtom,
   increasedTileLimitsAtom,
   swimUnitAtom,
@@ -146,6 +147,9 @@ function FoodSettings() {
   const [totalsPosition, setTotalsPosition] = useAtom(
     foodLogTotalsPositionAtom
   );
+  const [showCopyIndividualButton, setShowCopyIndividualButton] = useAtom(
+    foodLogShowCopyIndividualButtonAtom
+  );
 
   return (
     <>
@@ -160,6 +164,15 @@ function FoodSettings() {
             <MenuItem value="bottom">On bottom</MenuItem>
             <MenuItem value="both">Both top/bottom</MenuItem>
           </Select>
+        }
+      />
+      <SettingsRow
+        title="Show copy to clipboard button for individual values"
+        action={
+          <Switch
+            checked={showCopyIndividualButton}
+            onChange={(event, value) => setShowCopyIndividualButton(value)}
+          />
         }
       />
     </>

--- a/src/storage/settings.ts
+++ b/src/storage/settings.ts
@@ -50,6 +50,15 @@ export const foodLogTotalsPositionAtom = atomWithStorage<
   getOnInit: true,
 });
 
+export const foodLogShowCopyIndividualButtonAtom = atomWithStorage<boolean>(
+  "food-log:show-copy-individual-button",
+  false,
+  undefined,
+  {
+    getOnInit: true,
+  }
+);
+
 export const mapStyleAtom = atomWithStorage<string>(
   "map:style",
   "white",


### PR DESCRIPTION
@nicolas-girod Per https://github.com/jlai/fitness-dashboard/discussions/59 disable the individual copy values buttons by default, since I think most users would rather copy the entire row.

- Only show copy buttons if enabled in settings
- Reformat using prettier