### PR TITLE
Fix: tracker activities with zero distance render a literal "0" instead of nothing

### DIFF
--- a/src/api/activity/activities.ts
+++ b/src/api/activity/activities.ts
@@ -109,7 +109,7 @@ export function buildCreateActivityLogMutation(queryClient: QueryClient) {
 export function isPossiblyTracked(activity: ActivityLog) {
   return (
     (activity.logType === "mobile_run" || activity.logType === "tracker") &&
-    activity.distance
+    (activity.distance ?? 0) > 0
   );
 }
 


### PR DESCRIPTION
## The bug

In the activity log list, a small compass icon is meant to indicate a device-tracked
activity that has a real distance (implying it's worth opening for a route/pace view).
It's rendered as:

```tsx
{isPossiblyTracked(activityLog) && <LaunchIcon className="text-slate-500" />}
```

`isPossiblyTracked` is defined as:

```ts
export function isPossiblyTracked(activity: ActivityLog) {
  return (
    (activity.logType === "mobile_run" || activity.logType === "tracker") &&
    activity.distance
  );
}
```

This returns `activity.distance` directly rather than a boolean. For an activity
that IS tracker-sourced but has `distance: 0` (e.g. Tennis, Soccer -- court sports
where the device records a session but no meaningful distance), the `&&` chain
evaluates to the number `0`.

React treats `false`, `null`, and `undefined` as empty when used in JSX, but
renders `0` as literal text. So instead of showing nothing (the intended behavior
-- same as a non-tracked activity), these rows show a stray "0" next to the date.

## Repro

1. Log or sync any tracker-sourced activity type that Fitbit associates with a
   distance field (e.g. Tennis, Soccer) where the recorded distance rounds to 0.
2. View the Activities history list.
3. Observe a literal "0" rendered next to the date, instead of no icon.

## The fix

```diff
export function isPossiblyTracked(activity: ActivityLog) {
  return (
    (activity.logType === "mobile_run" || activity.logType === "tracker") &&
-   activity.distance
+   (activity.distance ?? 0) > 0
  );
}
```

Returns a real boolean, so the render is either the tracked-activity icon or
nothing, matching the original intent. Also guards against `distance` being
`undefined`.

## Testing

Verified against real account data: activities with `logType: "tracker"` and
`distance: 0` (zero-distance tracker sessions) now render no icon, matching
activities where the logType check fails outright. Activities with nonzero
distance are unaffected and continue to show the icon.
