### PR TITLE
Fix activity delete silently failing for logIds above Number.MAX_SAFE_INTEGER

### DIFF
--- a/src/__tests__/api/request.test.ts
+++ b/src/__tests__/api/request.test.ts
@@ -1,0 +1,28 @@
+import { getJSON } from "@/api/request";
+
+describe("getJSON", () => {
+  it("parses ids larger than Number.MAX_SAFE_INTEGER without losing precision", async () => {
+    const body = JSON.stringify({
+      activities: [{ logId: "BIG_ID", steps: 5000, distance: 1.5 }],
+    }).replace('"BIG_ID"', "2369048793018741424");
+
+    const response = { text: async () => body } as Response;
+
+    const parsed = await getJSON<{
+      activities: Array<{
+        logId: number | bigint;
+        steps: number;
+        distance: number;
+      }>;
+    }>(response);
+
+    const [activity] = parsed.activities;
+
+    // JSON.parse would round this to 2369048793018741000
+    expect(activity.logId).toBe(BigInt("2369048793018741424"));
+
+    // safe integers and floats are unaffected
+    expect(activity.steps).toBe(5000);
+    expect(activity.distance).toBe(1.5);
+  });
+});

--- a/src/api/activity/activities.ts
+++ b/src/api/activity/activities.ts
@@ -16,9 +16,11 @@ import {
   GetActivityLogResponse,
 } from "./types";
 
-export function buildGetActivityLogQuery(id: number) {
+export function buildGetActivityLogQuery(id: number | bigint) {
   return queryOptions({
-    queryKey: ["activity-log", id],
+    // logIds can exceed Number.MAX_SAFE_INTEGER; stringify since the default
+    // query key hasher (JSON.stringify) throws on BigInts
+    queryKey: ["activity-log", String(id)],
     queryFn: async () => {
       const response = await makeRequest(`/1.1/user/-/activities/${id}.json`);
 
@@ -28,9 +30,9 @@ export function buildGetActivityLogQuery(id: number) {
   });
 }
 
-export function buildActivityTcxQuery(id: number) {
+export function buildActivityTcxQuery(id: number | bigint) {
   return queryOptions({
-    queryKey: ["activity-tcx", id],
+    queryKey: ["activity-tcx", String(id)],
     queryFn: async () => {
       const response = await makeRequest(
         `/1/user/-/activities/${id}.tcx?includePartialTCX=true`
@@ -129,7 +131,7 @@ export function buildGetActivityListInfiniteQuery(
       const response = await makeRequest(
         `/1/user/-/activities/list.json?${queryString}`
       );
-      return (await response.json()) as GetActivityLogListResponse;
+      return await getJSON<GetActivityLogListResponse>(response);
     },
     getNextPageParam: (lastPage) =>
       lastPage.pagination.next
@@ -141,7 +143,7 @@ export function buildGetActivityListInfiniteQuery(
 
 export function buildDeleteActivityLogMutation(queryClient: QueryClient) {
   return mutationOptions({
-    mutationFn: async (activityLogId: number) => {
+    mutationFn: async (activityLogId: number | bigint) => {
       await makeRequest(`/1/user/-/activities/${activityLogId}.json`, {
         method: "DELETE",
         ignore502: true,

--- a/src/api/activity/types.ts
+++ b/src/api/activity/types.ts
@@ -47,7 +47,7 @@ export interface DailySummaryActivityLog {
   hasStartTime: boolean;
   isFavorite: boolean;
   lastModified: string;
-  logId: number;
+  logId: number | bigint;
   name: string;
   startDate: string;
   startTime: string;
@@ -69,7 +69,7 @@ export interface ActivityLog {
   elevationGain: number;
   heartRateZones: Array<HeartRateZone>;
   lastModified: string;
-  logId: number;
+  logId: number | bigint;
   logType: "auto_detected" | "manual" | "mobile_run" | "tracker";
   originalDuration: number;
   originalStartTime: string;

--- a/src/app/(dashboard)/tiles/activities.tsx
+++ b/src/app/(dashboard)/tiles/activities.tsx
@@ -27,7 +27,7 @@ import { useDailySummary } from "./common";
 import { useTileScale } from "./tile";
 import { IconWithDialog, RenderDialogContentProps } from "./tile-with-dialog";
 
-const showingLogIdAtom = atom<number | null>(null);
+const showingLogIdAtom = atom<number | bigint | null>(null);
 
 export default function ActivitiesTileContent() {
   const { h } = useTileScale();
@@ -64,7 +64,7 @@ export default function ActivitiesTileContent() {
         <List disablePadding className="w-full flex-1 overflow-y-auto">
           {activities.map((activityLog) => (
             <ActivityLogSummary
-              key={activityLog.logId}
+              key={String(activityLog.logId)}
               activityLog={activityLog}
             />
           ))}

--- a/src/app/history/activities/activity-log-list.tsx
+++ b/src/app/history/activities/activity-log-list.tsx
@@ -41,7 +41,7 @@ function ActivityLogRow({ logEntry: activityLog }: { logEntry: ActivityLog }) {
 
   const showActivityLogDetails = (event: React.MouseEvent) => {
     // Prepopulate query cache
-    queryClient.setQueryData(["activity-log", logId], activityLog);
+    queryClient.setQueryData(["activity-log", String(logId)], activityLog);
 
     setHashLogId(logId);
 
@@ -49,7 +49,7 @@ function ActivityLogRow({ logEntry: activityLog }: { logEntry: ActivityLog }) {
   };
 
   return (
-    <TableRow key={logId}>
+    <TableRow key={String(logId)}>
       <TableCell>
         <a onClick={showActivityLogDetails} href={`#activityLogId=${logId}`}>
           <div className="flex flex-row items-center gap-x-2">

--- a/src/app/history/activities/details/atoms.tsx
+++ b/src/app/history/activities/details/atoms.tsx
@@ -3,12 +3,20 @@ import { atomWithHash } from "jotai-location";
 
 import { cleanHashReplaceState } from "@/utils/hash";
 
-export const activityLogIdHashAtom = atomWithHash<number | null>(
+export const activityLogIdHashAtom = atomWithHash<number | bigint | null>(
   "activityLogId",
   null,
   {
-    serialize: (value: number | null) => (value ? value.toString() : ""),
-    deserialize: (value: string) => Number.parseInt(value) || null,
+    serialize: (value: number | bigint | null) =>
+      value ? value.toString() : "",
+    // Parse as BigInt since logIds can exceed Number.MAX_SAFE_INTEGER
+    deserialize: (value: string) => {
+      try {
+        return value ? BigInt(value) : null;
+      } catch {
+        return null;
+      }
+    },
     setHash: cleanHashReplaceState,
   }
 );

--- a/src/app/history/activities/details/dialog.tsx
+++ b/src/app/history/activities/details/dialog.tsx
@@ -24,7 +24,7 @@ export function ActivityLogDetailsDialog({
   open,
   onClose,
 }: {
-  logId: number;
+  logId: number | bigint;
   open: boolean;
   onClose: () => void;
 }) {

--- a/src/app/history/activities/details/load-tcx.ts
+++ b/src/app/history/activities/details/load-tcx.ts
@@ -47,7 +47,7 @@ export function useTcxDownloadUrl(
   return tcxDownloadUrl;
 }
 
-export function useFetchTcxAsString(activityLogId: number) {
+export function useFetchTcxAsString(activityLogId: number | bigint) {
   const { data: tcxString } = useQuery(buildActivityTcxQuery(activityLogId));
   return tcxString;
 }

--- a/src/components/history-list/history-list.tsx
+++ b/src/components/history-list/history-list.tsx
@@ -20,7 +20,7 @@ import { useState, useCallback } from "react";
 import JumpTo from "../jump-to";
 
 interface LogEntryWithId {
-  logId: number;
+  logId: number | bigint;
 }
 
 interface RowElementProps<Log> {
@@ -101,7 +101,7 @@ export default function HistoryList<Response, Log extends LogEntryWithId>({
         </TableHead>
         <TableBody>
           {logEntries.map((log) => (
-            <Row key={log.logId} logEntry={log} />
+            <Row key={String(log.logId)} logEntry={log} />
           ))}
           {[...Array(pageSize - logEntries.length).fill(0)].map((_, i) => (
             <TableRow key={`filler-${i}`}>


### PR DESCRIPTION
Fixes #142.

## Root cause

The activity log **list** query was still parsing its response with plain `response.json()`:

```ts
return (await response.json()) as GetActivityLogListResponse;
```

`JSON.parse` rounds integers above `Number.MAX_SAFE_INTEGER` to the nearest representable double, so every `logId` in the history list arrives slightly wrong — e.g. `2369048793018741424` (per its own `tcxLink`) parses to `2369048793018741000`. The "Parse BigInts in food and activity JSON responses" commit (3e3f163) fixed the single-activity GET and the daily summary, but not this endpoint.

From there the symptoms in #142 all follow:

1. **The details dialog still opens fine** because clicking a row prepopulates the query cache with the list data (`queryClient.setQueryData(["activity-log", logId], activityLog)`), so no GET with the bad id ever hits the network.
2. **Delete sends the rounded id**, which matches no real activity, so the activity survives a refresh.
3. **The failure is silent** because the delete mutation passes `ignore502: true` (the workaround for Fitbit's spurious 502s on delete), so the error response for the bogus id is swallowed and the success toast still shows.

It also explains the confusing counterexample in the issue (a 19-digit `logId` that deleted fine): doubles in the 2^61 range represent exactly the multiples of 512, so a large id *can* survive `JSON.parse` intact — it depends on the id's low bits, not on how large it is. That's also why the failures correlated with activities synced in from Apple Health: they come from a different id-generation pipeline than tracker/app-created logs, so their ids happen not to be representable. The `source` block itself plays no role — there's only one delete code path.

## Changes

- Parse the activity list response with `getJSON`, extending the existing BigInt parsing to the list endpoint. (`json-bigint-native` only converts integers outside the safe range, so `steps`, `calories`, etc. stay `number`s.)
- Type `logId` as `number | bigint` and thread that through the details dialog, hash atom, TCX query, and delete mutation. The delete URL is built with a template literal, so the full-precision id goes out on the wire.
- Stringify `logId`s used in **query keys**: TanStack Query's default key hasher is `JSON.stringify`, which throws `TypeError: Do not know how to serialize a BigInt`. This was already reachable before this PR — the dashboard activities tile receives BigInt `logId`s from the daily summary (BigInt-parsed since the earlier commit) and passes them into `buildGetActivityLogQuery`'s query key, so opening one of these activities from the tile would crash.
- Deserialize the `#activityLogId=` hash param with `BigInt()` instead of `Number.parseInt`, so direct links to affected activities keep full precision too (previously the fallback GET would 404 with the rounded id).
- Add a regression test that `getJSON` round-trips ids above `Number.MAX_SAFE_INTEGER` losslessly.

## Testing

- `tsc --noEmit`, `next lint`, and `jest` all pass (the one failing suite, `serving-size.test.tsx`, fails identically on `main`).
- Verified the parsing behavior directly: `json-bigint-native` round-trips `2369048793018741424` exactly, while `JSON.parse` yields `2369048793018741000` — the exact pair of values observed in #142.
- I haven't re-driven the full UI delete flow end-to-end yet, but the direct `DELETE` with the full-precision id (from `tcxLink`) described in #142 already succeeded with a 200 against my account, and that's the same request this change now makes the UI send. Happy to verify differently if you'd like.
